### PR TITLE
Update rules

### DIFF
--- a/src/main/resources/net/kemitix/pmd/java.xml
+++ b/src/main/resources/net/kemitix/pmd/java.xml
@@ -232,7 +232,7 @@ http://pmd.sourceforge.net/ruleset/2.0.0 ">
     <rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod"/>
     <rule ref="category/java/errorprone.xml/DataflowAnomalyAnalysis">
         <properties>
-            <property name="maxViolations" value="0"/>
+            <property name="maxViolations" value="1"/>
         </properties>
     </rule>
     <rule ref="category/java/errorprone.xml/DoNotCallGarbageCollectionExplicitly"/>

--- a/src/main/resources/net/kemitix/pmd/java.xml
+++ b/src/main/resources/net/kemitix/pmd/java.xml
@@ -188,7 +188,7 @@ http://pmd.sourceforge.net/ruleset/2.0.0 ">
         <properties>
             <property name="enumCommentRequirement" value="Ignored"/>
             <property name="fieldCommentRequirement" value="Ignored"/>
-            <property name="headerCommentRequirement" value="Ignored"/>
+            <property name="classCommentRequirement" value="Ignored"/>
             <!-- only public and protected methods are required -->
         </properties>
     </rule>

--- a/src/main/resources/net/kemitix/pmd/java.xml
+++ b/src/main/resources/net/kemitix/pmd/java.xml
@@ -269,7 +269,6 @@ http://pmd.sourceforge.net/ruleset/2.0.0 ">
     <rule ref="category/java/errorprone.xml/JumbledIncrementer" />
     <rule ref="category/java/errorprone.xml/JUnitSpelling" />
     <rule ref="category/java/errorprone.xml/JUnitStaticSuite" />
-    <rule ref="category/java/errorprone.xml/LoggerIsNotStaticFinal" />
     <rule ref="category/java/errorprone.xml/MethodWithSameNameAsEnclosingClass" />
     <rule ref="category/java/errorprone.xml/MisplacedNullCheck" />
     <rule ref="category/java/errorprone.xml/MissingBreakInSwitch" />

--- a/src/main/resources/net/kemitix/pmd/java.xml
+++ b/src/main/resources/net/kemitix/pmd/java.xml
@@ -309,7 +309,6 @@ http://pmd.sourceforge.net/ruleset/2.0.0 ">
     <rule ref="category/java/multithreading.xml/DontCallThreadRun" />
     <rule ref="category/java/multithreading.xml/DoubleCheckedLocking" />
     <rule ref="category/java/multithreading.xml/NonThreadSafeSingleton" />
-    <rule ref="category/java/multithreading.xml/UnsynchronizedStaticDateFormatter" />
     <rule ref="category/java/multithreading.xml/UseConcurrentHashMap" />
     <rule ref="category/java/multithreading.xml/UseNotifyAllInsteadOfNotify" />
 

--- a/src/main/resources/net/kemitix/pmd/java.xml
+++ b/src/main/resources/net/kemitix/pmd/java.xml
@@ -265,7 +265,7 @@ http://pmd.sourceforge.net/ruleset/2.0.0 ">
     <rule ref="category/java/errorprone.xml/IdempotentOperations" />
     <rule ref="category/java/errorprone.xml/ImportFromSamePackage" />
     <rule ref="category/java/errorprone.xml/InstantiationToGetClass" />
-    <rule ref="category/java/errorprone.xml/InvalidSlf4jMessageFormat" />
+    <rule ref="category/java/errorprone.xml/InvalidLogMessageFormat" />
     <rule ref="category/java/errorprone.xml/JumbledIncrementer" />
     <rule ref="category/java/errorprone.xml/JUnitSpelling" />
     <rule ref="category/java/errorprone.xml/JUnitStaticSuite" />


### PR DESCRIPTION
- Remove deprecated rule LoggerIsNotStaticFinal
- Replace deprecated rule with InvalidLogMessageFormat
- Fix CommentRequired uses a deprecated property
- Fix constraints for DataflowAnomalyAnalysis
