### PR TITLE
Remove deprecated rule AvoidUsingShortType

### DIFF
--- a/src/main/resources/net/kemitix/pmd/java.xml
+++ b/src/main/resources/net/kemitix/pmd/java.xml
@@ -308,7 +308,6 @@ http://pmd.sourceforge.net/ruleset/2.0.0 ">
     <rule ref="category/java/performance.xml/AvoidArrayLoops" />
     <rule ref="category/java/performance.xml/AvoidFileStream" />
     <rule ref="category/java/performance.xml/AvoidInstantiatingObjectsInLoops" />
-    <rule ref="category/java/performance.xml/AvoidUsingShortType" />
     <rule ref="category/java/performance.xml/BigIntegerInstantiation" />
     <rule ref="category/java/performance.xml/BooleanInstantiation" />
     <rule ref="category/java/performance.xml/ByteInstantiation" />


### PR DESCRIPTION
Closes #26 