### PR TITLE
Replace deprecated rule DoNotCallSystemExit with DoNotTerminateVM

### DIFF
--- a/src/main/resources/net/kemitix/pmd/java.xml
+++ b/src/main/resources/net/kemitix/pmd/java.xml
@@ -227,7 +227,7 @@ http://pmd.sourceforge.net/ruleset/2.0.0 ">
     <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals"/>
     <rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod"/>
     <rule ref="category/java/errorprone.xml/DoNotCallGarbageCollectionExplicitly"/>
-    <rule ref="category/java/errorprone.xml/DoNotCallSystemExit"/>
+    <rule ref="category/java/errorprone.xml/DoNotTerminateVM"/>
     <rule ref="category/java/errorprone.xml/DoNotExtendJavaLangThrowable"/>
     <rule ref="category/java/errorprone.xml/DoNotHardCodeSDCard"/>
     <rule ref="category/java/errorprone.xml/DoNotThrowExceptionInFinally"/>


### PR DESCRIPTION
Closes #25 